### PR TITLE
common-odm: add libsnsapi dependency

### DIFF
--- a/common-odm.mk
+++ b/common-odm.mk
@@ -50,6 +50,7 @@ PRODUCT_PACKAGES += \
 # Sensors
 PRODUCT_PACKAGES += \
     sscrpcd \
+    libsnsapi \
     libsensor_reg  \
     libsensor1 \
     sensors.msm8226 \


### PR DESCRIPTION
the library is used by the new camera framework

Signed-off-by: Alin Jerpelea <alin.jerpelea@sony.com>